### PR TITLE
Fix for one letter named field and for tests

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/FieldNameRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/FieldNameRule.java
@@ -36,10 +36,15 @@ public class FieldNameRule extends DelphiRule {
       if (!isPublished()) {
         Tree variableIdentsNode = node.getChild(0);
         String name = variableIdentsNode.getChild(0).getText();
-        char firstCharAfterPrefix = name.charAt(1);
+        if (name.length() > 1) {
+	        char firstCharAfterPrefix = name.charAt(1);
 
-        if (!name.startsWith("F") || firstCharAfterPrefix != Character.toUpperCase(firstCharAfterPrefix)) {
-          addViolation(data, node);
+	        if (!name.startsWith("F") || firstCharAfterPrefix != Character.toUpperCase(firstCharAfterPrefix)) {
+	          addViolation(data, node);
+	        }
+        } else {
+        	// a single letter name has no prefix 
+        	addViolation(data, node);
         }
       }
     }

--- a/src/test/java/org/sonar/plugins/delphi/pmd/FieldNameRuleTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/pmd/FieldNameRuleTest.java
@@ -116,4 +116,19 @@ public class FieldNameRuleTest extends BasePmdRuleTest {
     assertThat(issues, hasItem(allOf(hasRuleKey("FieldNameRule"), hasRuleLine(builder.getOffsetDecl() + 4))));
   }
 
+  @Test
+  public void testOneLetterNameField() {
+    DelphiUnitBuilderTest builder = new DelphiUnitBuilderTest();
+    builder.appendDecl("type");
+    builder.appendDecl("  TMyClass = class");
+    builder.appendDecl("    private");
+    builder.appendDecl("     x: Integer;");
+    builder.appendDecl("  end;");
+
+    analyse(builder);
+
+    assertThat(issues, hasSize(1));
+    assertThat(issues, hasItem(hasRuleKeyAtLine("FieldNameRule", builder.getOffsetDecl() + 4)));
+  }
+  
 }

--- a/src/test/java/org/sonar/plugins/delphi/surefire/SurefireSensorTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/surefire/SurefireSensorTest.java
@@ -105,7 +105,7 @@ public class SurefireSensorTest {
       System.out.println(key + ":" + context.getMeasure(key));
     }
 
-    assertEquals(18, context.getMeasuresKeys().size());
+    assertEquals(24, context.getMeasuresKeys().size());
   }
 
 }

--- a/src/test/resources/org/sonar/plugins/delphi/SimpleDelphiProject/target/surefire-reports/Coverage.xml
+++ b/src/test/resources/org/sonar/plugins/delphi/SimpleDelphiProject/target/surefire-reports/Coverage.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="Windows-1252" standalone="no"?>
+<report>
+  <stats>
+    <packages value="1"/>
+    <classes value="2"/>
+    <methods value="3"/>
+    <srcfiles value="4"/>
+    <srclines value="5"/>
+    <totallines value="6"/>
+    <coveredlines value="7"/>
+    <coveredpercent value="8"/>
+  </stats>
+  <data>
+    <all name="all classes">
+      <coverage type="class, %" value="41%   (41/101)"/>
+      <coverage type="method, %" value="18%   (112/636)"/>
+      <coverage type="block, %" value="12%   (815/6924)"/>
+      <coverage type="line, %" value="12%   (815/6924)"/>
+      <package name="[default]">
+        <coverage type="class, %" value="100%   (5/5)"/>
+        <coverage type="method, %" value="74%   (14/19)"/>
+        <coverage type="block, %" value="66%   (93/140)"/>
+        <coverage type="line, %" value="66%   (93/140)"/>
+        <srcfile name="MainWindow.pas">
+          <coverage type="class, %" value="100%   (5/5)"/>
+          <coverage type="method, %" value="74%   (14/19)"/>
+          <coverage type="block, %" value="66%   (93/140)"/>
+          <coverage type="line, %" value="66%   (93/140)"/>
+          <class name="TMainWindow">
+            <coverage type="class, %" value="100%   (1/1)"/>
+            <coverage type="method, %" value="100%   (1/1)"/>
+            <coverage type="block, %" value="56%   (5/9)"/>
+            <coverage type="line, %" value="56%   (5/9)"/>
+            <method name="foo2">
+              <coverage type="method, %" value="100%   (1/1)"/>
+              <coverage type="block, %" value="56%   (5/9)"/>
+              <coverage type="line, %" value="56%   (5/9)"/>
+              <line number="36" covered="True"/>
+              <line number="37" covered="False"/>
+              <line number="38" covered="True"/>
+              <line number="39" covered="False"/>
+            </method>
+          </class>         
+        </srcfile>
+        <srcfile name="Globals.pas">
+          <coverage type="class, %" value="100%   (5/5)"/>
+          <coverage type="method, %" value="74%   (14/19)"/>
+          <coverage type="block, %" value="66%   (93/140)"/>
+          <coverage type="line, %" value="66%   (93/140)"/>
+          <class name="TGlobals">
+            <coverage type="class, %" value="100%   (1/1)"/>
+            <coverage type="method, %" value="100%   (1/1)"/>
+            <coverage type="block, %" value="56%   (5/9)"/>
+            <coverage type="line, %" value="56%   (5/9)"/>
+            <method name="globalProcedure">
+              <coverage type="method, %" value="100%   (2/2)"/>
+              <coverage type="block, %" value="100%   (1/1)"/>
+              <coverage type="line, %" value="100%   (2/2)"/>
+			  <line number="19" covered="True"/>
+              <line number="20" covered="True"/>
+            </method>
+          </class>         
+        </srcfile>
+      </package>
+    </all>
+  </data>
+</report>

--- a/src/test/resources/org/sonar/plugins/delphi/SimpleDelphiProject/target/surefire-reports/TEST-dunit-report.xml
+++ b/src/test/resources/org/sonar/plugins/delphi/SimpleDelphiProject/target/surefire-reports/TEST-dunit-report.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="myTestSuites" total="3" date="2011-01-01" time="00:00:30">
+   
+   <testsuite name="TEST_SUITE_1" success="True" time="0.025">
+      <testcase name="FunctionTest" classname="MyTest1"
+                success="True"
+                time="0.020"
+                executed="True"/>
+      <testcase name="ProcedureTest" classname="MyTest1"
+                success="True"
+                time="0.05"
+                executed="True"/>
+   </testsuite>
+
+   <testsuite name="TEST_SUITE_2" success="True" time="0.005">
+      <testcase name="FunctionTest2" classname="MyTest2"
+                success="True"
+                time="0.001"
+                executed="True"/>
+      <testcase name="ProcedureTest2" classname="MyTest2"
+                success="True"
+                time="0.004"
+                executed="True"/>
+   </testsuite>   
+   
+   <testsuite name="TEST_SUITE_3" success="True" time="0.005">
+      <testcase name="FunctionTest3"
+                success="True"
+                time="0.001"
+                executed="True"/>
+      <testcase name="ProcedureTest3"
+                success="True"
+                time="0.004"
+                executed="True"/>
+   </testsuite>      
+
+   <testsuite name="TEST_SUITE_4" success="True" time="0.007">
+      <testcase name="FunctionTest4"
+                success="True"
+                time="0.002"
+                executed="True"/>
+      <testcase name="ProcedureTest4"
+                success="True"
+                time="0.005"
+                executed="True"/>
+   </testsuite>
+
+</testsuites>


### PR DESCRIPTION
Hi! Thanks for great work moving this plug-in up to date with current SQ. I submit two small patches. The one-letter field name is straightforward. As for the test resources one - it might be some kind of configuration error on my side, but only by adding these resources it was possible to successfully run build and test. Best regards.
