### PR TITLE
Refactored DelphiRule.visit and DelphiRule.addViolation methods

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/AssignedAndFreeRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/AssignedAndFreeRule.java
@@ -24,9 +24,12 @@ package org.sonar.plugins.delphi.pmd.rules;
 
 import java.util.HashSet;
 import java.util.Set;
+
 import org.antlr.runtime.tree.Tree;
 import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
+
+import net.sourceforge.pmd.RuleContext;
 
 /**
  * Class for checking if we are using .Free with checking if variable is
@@ -39,7 +42,7 @@ public class AssignedAndFreeRule extends DelphiRule {
   protected Set<String> variables;
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
     if (node.getType() == DelphiLexer.IF) {
       started = true;
       variables.clear();
@@ -63,11 +66,9 @@ public class AssignedAndFreeRule extends DelphiRule {
       }
 
       else if ("free".equalsIgnoreCase(node.getText()) && freeVariable(node)) {
-        addViolation(data, node);
+        addViolation(ctx, node);
       }
     }
-
-    return data;
   }
 
   private boolean freeVariable(DelphiPMDNode node) {

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/BlockCounterRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/BlockCounterRule.java
@@ -24,6 +24,8 @@ package org.sonar.plugins.delphi.pmd.rules;
 
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 /**
  * Rule that count's the number of lines between to statement pairs. Produces a
  * violation if the number of lines exceeds limit.
@@ -85,8 +87,8 @@ public class BlockCounterRule extends CountRule {
    */
 
   @Override
-  protected void addViolation(Object data, DelphiPMDNode node) {
-    super.addViolation(data, firstNode);
+  protected void addViolation(RuleContext ctx, DelphiPMDNode node) {
+    super.addViolation(ctx, firstNode);
   }
 
   /**

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/CastAndFreeRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/CastAndFreeRule.java
@@ -55,7 +55,7 @@ public class CastAndFreeRule extends DelphiRule {
     sequenceSoftCastIndex = processSequence(softCastSequence, sequenceSoftCastIndex, node, ctx);
   }
 
-  private int processSequence(LexerMetrics sequence[], int sequenceIndex, DelphiPMDNode node, Object data) {
+  private int processSequence(LexerMetrics sequence[], int sequenceIndex, DelphiPMDNode node, RuleContext ctx) {
     int resultIndex = sequenceIndex;
     if (resultIndex >= sequence.length) {
       resultIndex = 0;
@@ -64,7 +64,7 @@ public class CastAndFreeRule extends DelphiRule {
       ++resultIndex;
       if (isCorrectSequence(sequence, resultIndex, node)) {
         resultIndex = 0;
-        addViolation(data, node);
+        addViolation(ctx, node);
       }
     }
     else {

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/CastAndFreeRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/CastAndFreeRule.java
@@ -26,6 +26,8 @@ import org.antlr.runtime.tree.Tree;
 import org.sonar.plugins.delphi.antlr.analyzer.LexerMetrics;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 /**
  * Cast And Free rule - don't cast, just to free something, example:
  * TMyObject(sth).free; (sth as TMyObject).free;
@@ -48,10 +50,9 @@ public class CastAndFreeRule extends DelphiRule {
   }
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
-    sequenceHardCastIndex = processSequence(hardCastSequence, sequenceHardCastIndex, node, data);
-    sequenceSoftCastIndex = processSequence(softCastSequence, sequenceSoftCastIndex, node, data);
-    return data;
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
+    sequenceHardCastIndex = processSequence(hardCastSequence, sequenceHardCastIndex, node, ctx);
+    sequenceSoftCastIndex = processSequence(softCastSequence, sequenceSoftCastIndex, node, ctx);
   }
 
   private int processSequence(LexerMetrics sequence[], int sequenceIndex, DelphiPMDNode node, Object data) {

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/ClassNameRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/ClassNameRule.java
@@ -21,10 +21,12 @@ package org.sonar.plugins.delphi.pmd.rules;
 import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 public class ClassNameRule extends DelphiRule {
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
 
     if (node.getType() == DelphiLexer.TkClass) {
       String name = node.getParent().getText();
@@ -32,10 +34,8 @@ public class ClassNameRule extends DelphiRule {
       char firstCharAfterPrefix = name.charAt(1);
 
       if ((!name.startsWith("T") && !name.startsWith("E")) || firstCharAfterPrefix != Character.toUpperCase(firstCharAfterPrefix)) {
-        addViolation(data, node);
+        addViolation(ctx, node);
       }
     }
-
-    return data;
   }
 }

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/CountRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/CountRule.java
@@ -24,6 +24,8 @@ package org.sonar.plugins.delphi.pmd.rules;
 
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 /**
  * Rule that counts the number of specified nodes, and if the count exceeds the
  * specified limit, rule will produce a violation
@@ -57,19 +59,18 @@ public class CountRule extends DelphiRule {
   }
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
-    dataRef = data;
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
+    dataRef = ctx;
     if (shouldCount(node)) {
       increaseCounter(strength);
     }
 
     if (exceedsLimit()) {
-      addViolation(data, node);
+      addViolation(ctx, node);
       if (reset) {
         count = 0;
       }
     }
-    return data;
   }
 
   protected boolean shouldCount(DelphiPMDNode node) {

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/DelphiRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/DelphiRule.java
@@ -56,8 +56,8 @@ public class DelphiRule extends AbstractJavaRule {
   /**
    * overload this method in derived class
    */
-  public Object visit(DelphiPMDNode node, Object data) {
-    return data;
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
+    // do nothing
   }
 
   /**

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/DelphiRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/DelphiRule.java
@@ -99,35 +99,31 @@ public class DelphiRule extends AbstractJavaRule {
   /**
    * Adds violation, get violation data from node
    * 
-   * @param data Data
+   * @param ctx RuleContext
    * @param node Node
    */
-  protected void addViolation(Object data, DelphiPMDNode node) {
-    RuleContext ctx = (RuleContext) data;
+  protected void addViolation(RuleContext ctx, DelphiPMDNode node) {
     ctx.getReport().addRuleViolation(new DelphiRuleViolation(this, ctx, node));
   }
 
   /**
    * Adds violation, get violation data from node
    * 
-   * @param data Data
+   * @param ctx RuleContext
    * @param node Node
    * @param msg Violation message
    */
-  protected void addViolation(Object data, DelphiPMDNode node, String msg) {
-
-    RuleContext ctx = (RuleContext) data;
+  protected void addViolation(RuleContext ctx, DelphiPMDNode node, String msg) {
     ctx.getReport().addRuleViolation(new DelphiRuleViolation(this, ctx, node, msg));
   }
 
   /**
    * Adds violation, used in XPathRule
    * 
-   * @param data Data
+   * @param ctx RuleContext
    * @param violation Violation
    */
-  protected void addViolation(Object data, DelphiRuleViolation violation) {
-    RuleContext ctx = (RuleContext) data;
+  protected void addViolation(RuleContext ctx, DelphiRuleViolation violation) {
     ctx.getReport().addRuleViolation(violation);
   }
 

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/DprFunctionRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/DprFunctionRule.java
@@ -25,6 +25,8 @@ package org.sonar.plugins.delphi.pmd.rules;
 import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 /**
  * Rule class searching for procedures, functions and variables in a .dpr file
  */
@@ -42,7 +44,7 @@ public class DprFunctionRule extends DelphiRule {
   }
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
     // checking if we are on .dpr/.dpk
     if (check == -1) {
       if (node.getASTTree().getFileName().endsWith(".dpr") || node.getASTTree().getFileName().endsWith(".dpk")) {
@@ -53,14 +55,12 @@ public class DprFunctionRule extends DelphiRule {
     }
     if (check != 1) {
       // not a .dpr/.dpk file
-      return data;
+      return;
     }
 
     if (isViolationNode(node)) {
-      addViolation(data, node);
+      addViolation(ctx, node);
     }
-
-    return data;
   }
 
   /**

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/FieldNameRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/FieldNameRule.java
@@ -22,6 +22,8 @@ import org.antlr.runtime.tree.Tree;
 import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 public class FieldNameRule extends DelphiRule {
 
   @Override
@@ -30,7 +32,7 @@ public class FieldNameRule extends DelphiRule {
   }
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
     if (node.getType() == DelphiLexer.TkClassField) {
 
       if (!isPublished()) {
@@ -40,16 +42,14 @@ public class FieldNameRule extends DelphiRule {
 	        char firstCharAfterPrefix = name.charAt(1);
 
 	        if (!name.startsWith("F") || firstCharAfterPrefix != Character.toUpperCase(firstCharAfterPrefix)) {
-	          addViolation(data, node);
+	          addViolation(ctx, node);
 	        }
         } else {
         	// a single letter name has no prefix 
-        	addViolation(data, node);
+          addViolation(ctx, node);
         }
       }
     }
-
-    return data;
   }
 
 }

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/InterfaceNameRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/InterfaceNameRule.java
@@ -22,10 +22,12 @@ import org.antlr.runtime.tree.Tree;
 import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 public class InterfaceNameRule extends DelphiRule {
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
 
     if (node.getType() == DelphiLexer.TkNewType) {
       Tree candidateNode = node.getChild(0).getChild(0);
@@ -36,11 +38,9 @@ public class InterfaceNameRule extends DelphiRule {
         char firstCharAfterPrefix = name.charAt(1);
 
         if (!name.startsWith("I") || firstCharAfterPrefix != Character.toUpperCase(firstCharAfterPrefix)) {
-          addViolation(data, (DelphiPMDNode) candidateNode);
+          addViolation(ctx, (DelphiPMDNode) candidateNode);
         }
       }
     }
-
-    return data;
   }
 }

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/MethodNameRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/MethodNameRule.java
@@ -23,10 +23,12 @@ import org.antlr.runtime.tree.Tree;
 import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 public class MethodNameRule extends DelphiRule {
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
 
     if (node.getType() == DelphiLexer.TkNewType) {
       if (isInterface(node) || !isPublished()) {
@@ -37,13 +39,11 @@ public class MethodNameRule extends DelphiRule {
           char firstChar = name.charAt(0);
 
           if (firstChar != Character.toUpperCase(firstChar)) {
-            addViolation(data, (DelphiPMDNode) method);
+            addViolation(ctx, (DelphiPMDNode) method);
           }
         }
       }
     }
-
-    return data;
   }
 
 }

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/MixedNamesRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/MixedNamesRule.java
@@ -29,6 +29,8 @@ import org.antlr.runtime.tree.Tree;
 import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 /**
  * Rule that checks if you are using function/variables names correctly, that is
  * you don't mispell them, example: <code>var
@@ -56,7 +58,7 @@ public class MixedNamesRule extends DelphiRule {
   }
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
     int type = node.getType();
     switch (type) {
       case DelphiLexer.IMPLEMENTATION:
@@ -70,7 +72,7 @@ public class MixedNamesRule extends DelphiRule {
         if (onInterface) {
           functionNames.addAll(buildNames(node, false));
         } else {
-          checkFunctionNames(node, data);
+          checkFunctionNames(node, ctx);
         }
         break;
       case DelphiLexer.VAR:
@@ -80,11 +82,10 @@ public class MixedNamesRule extends DelphiRule {
         break;
       case DelphiLexer.BEGIN:
         if (!onInterface) {
-          checkVariableNames(node, data, true);
+          checkVariableNames(node, ctx, true);
         }
         break;
     }
-    return data;
   }
 
   /**

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/MixedNamesRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/MixedNamesRule.java
@@ -91,7 +91,7 @@ public class MixedNamesRule extends DelphiRule {
   /**
    * Check variable names between begin...end statements
    */
-  protected void checkVariableNames(DelphiPMDNode node, Object data, boolean clear) {
+  protected void checkVariableNames(DelphiPMDNode node, RuleContext ctx, boolean clear) {
     for (int i = 0; i < node.getChildCount(); ++i) {
 
       // Cast exception was thrown, so we use c-tor instead of casting to DelphiPMDNode
@@ -100,12 +100,12 @@ public class MixedNamesRule extends DelphiRule {
         lastLineParsed = child.getLine();
       }
       if (child.getType() == DelphiLexer.BEGIN) {
-        checkVariableNames(child, data, false);
+        checkVariableNames(child, ctx, false);
       } else {
         for (String globalName : variableNames) {
           if (child.getText().equalsIgnoreCase(globalName.toLowerCase())
             && !child.getText().equals(globalName)) {
-            addViolation(data, child, "Avoid mixing variable names (found: '" + child.getText()
+            addViolation(ctx, child, "Avoid mixing variable names (found: '" + child.getText()
               + "' expected: '" + globalName + "').");
           }
         }
@@ -120,12 +120,12 @@ public class MixedNamesRule extends DelphiRule {
   /**
    * Check function names
    */
-  protected void checkFunctionNames(DelphiPMDNode node, Object data) {
+  protected void checkFunctionNames(DelphiPMDNode node, RuleContext ctx) {
     List<String> currentNames = buildNames(node, false);
     for (String name : currentNames) {
       for (String globalName : functionNames) {
         if (name.equalsIgnoreCase(globalName.toLowerCase()) && !name.equals(globalName)) {
-          addViolation(data, node, "Avoid mixing function names (found: '" + name + "' expected: '"
+          addViolation(ctx, node, "Avoid mixing function names (found: '" + name + "' expected: '"
             + globalName + "').");
         }
       }

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/NoBeginAfterDoRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/NoBeginAfterDoRule.java
@@ -26,23 +26,23 @@ import org.antlr.runtime.tree.Tree;
 import org.sonar.plugins.delphi.antlr.analyzer.LexerMetrics;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 /**
  * Checks, if we put 'begin' after 'do' statement
  */
 public class NoBeginAfterDoRule extends DelphiRule {
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
     if (shouldCheck(node)) {
       Tree nextNode = node.getParent().getChild(node.getChildIndex() + 1);
 
       if (isWrongNode(nextNode)) {
-        addViolation(data, node);
+        addViolation(ctx, node);
       }
 
     }
-
-    return data;
   }
 
   protected boolean isWrongNode(Tree node) {

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/NoInheritedStatementRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/NoInheritedStatementRule.java
@@ -27,6 +27,8 @@ import org.apache.commons.lang.StringUtils;
 import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 /**
  * Class that checks if 'inherited' statement is in some function or procedure.
  * If no, it triggers a violation.
@@ -41,9 +43,9 @@ public class NoInheritedStatementRule extends DelphiRule {
   }
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
     if (StringUtils.isEmpty(lookFor)) {
-      return data;
+      return;
     }
 
     if (node.getText().equalsIgnoreCase(lookFor)) {
@@ -65,12 +67,10 @@ public class NoInheritedStatementRule extends DelphiRule {
         }
 
         if (!wasInherited) {
-          addViolation(data, node);
+          addViolation(ctx, node);
         }
       }
     }
-
-    return data;
   }
 
 }

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/NoSemicolonRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/NoSemicolonRule.java
@@ -27,6 +27,8 @@ import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.analyzer.LexerMetrics;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 /**
  * Checks if semicolons are properly placed
  */
@@ -40,10 +42,10 @@ public class NoSemicolonRule extends DelphiRule {
   }
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
     if (!inImplementation) {
       inImplementation = node.getType() == LexerMetrics.IMPLEMENTATION.toMetrics();
-      return data;
+      return;
     }
 
     if (node.getType() == LexerMetrics.END.toMetrics()) {
@@ -51,15 +53,14 @@ public class NoSemicolonRule extends DelphiRule {
       if (isValidNode(previousNode)) {
         if (isBlockNode(previousNode)) {
           if (isMissingSemicolonInBlock(previousNode)) {
-            addViolation(data, node);
+            addViolation(ctx, node);
           }
         } else if (!isSemicolonNode(previousNode)) {
-          addViolation(data, (DelphiPMDNode) previousNode);
+          addViolation(ctx, (DelphiPMDNode) previousNode);
         }
       }
 
     }
-    return data;
   }
 
   private boolean isValidNode(Tree node) {

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/NodeSequenceRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/NodeSequenceRule.java
@@ -22,6 +22,7 @@
  */
 package org.sonar.plugins.delphi.pmd.rules;
 
+import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.properties.StringProperty;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
@@ -39,22 +40,20 @@ public class NodeSequenceRule extends DelphiRule {
   private DelphiPMDNode firstMatchNode;
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
 
     if (node.getText().equalsIgnoreCase(sequence[count])) {
       if (++count == 1) {
         // save first match node
         firstMatchNode = node;
       } else if (count >= sequence.length) {
-        addViolation(data, firstMatchNode);
+        addViolation(ctx, firstMatchNode);
         count = 0;
       }
     } else {
       // reset if we bumped out of the sequence
       count = 0;
     }
-
-    return data;
   }
 
   @Override

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/PointerNameRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/PointerNameRule.java
@@ -21,6 +21,8 @@ package org.sonar.plugins.delphi.pmd.rules;
 import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 public class PointerNameRule extends DelphiRule {
 
   private boolean isImplementationSection;
@@ -32,13 +34,13 @@ public class PointerNameRule extends DelphiRule {
   }
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
     if (!isImplementationSection) {
       isImplementationSection = node.getType() == DelphiLexer.IMPLEMENTATION;
     }
 
     if (isImplementationSection) {
-      return data;
+      return;
     }
 
     if (node.getType() == DelphiLexer.POINTER2) {
@@ -47,10 +49,8 @@ public class PointerNameRule extends DelphiRule {
       char firstCharAfterPrefix = name.charAt(1);
 
       if (!name.startsWith("P") || firstCharAfterPrefix != Character.toUpperCase(firstCharAfterPrefix)) {
-        addViolation(data, node);
+        addViolation(ctx, node);
       }
     }
-
-    return data;
   }
 }

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/PublicFieldsRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/PublicFieldsRule.java
@@ -26,13 +26,15 @@ import org.antlr.runtime.tree.Tree;
 import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 /**
  * Class for checking if class fields are private or protected, not public
  */
 public class PublicFieldsRule extends DelphiRule {
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
     if (node.getType() == DelphiLexer.TkNewType) {
       // encountering new type, checking for its fields
       Tree parent = node.getChild(0);
@@ -44,12 +46,10 @@ public class PublicFieldsRule extends DelphiRule {
         } else if (isNotPublic(child.getType())) {
           isPublic = false;
         } else if (child.getType() == DelphiLexer.TkClassField && isPublic) {
-          addViolation(data, (DelphiPMDNode) child);
+          addViolation(ctx, (DelphiPMDNode) child);
         }
       }
     }
-
-    return data;
   }
 
   private boolean isNotPublic(int type) {

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/RecordNameRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/RecordNameRule.java
@@ -22,10 +22,12 @@ import org.antlr.runtime.tree.Tree;
 import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 public class RecordNameRule extends DelphiRule {
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
 
     if (node.getType() == DelphiLexer.TkNewType) {
       Tree candidateNode = node.getChild(0).getChild(0);
@@ -36,11 +38,9 @@ public class RecordNameRule extends DelphiRule {
         char firstCharAfterPrefix = name.charAt(1);
 
         if (!name.startsWith("T") || firstCharAfterPrefix != Character.toUpperCase(firstCharAfterPrefix)) {
-          addViolation(data, (DelphiPMDNode) candidateNode);
+          addViolation(ctx, (DelphiPMDNode) candidateNode);
         }
       }
     }
-
-    return data;
   }
 }

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/ThenTryRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/ThenTryRule.java
@@ -26,6 +26,8 @@ import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiNode;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 /**
  * "Try" should always be preceeded with "Begin" after "Then"
  * 
@@ -33,9 +35,9 @@ import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 public class ThenTryRule extends DelphiRule {
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
     if (node.getType() != DelphiLexer.THEN) {
-      return data;
+      return;
     }
 
     DelphiNode parent = (DelphiNode) node.getParent();
@@ -44,8 +46,7 @@ public class ThenTryRule extends DelphiRule {
     int nextNode = parent.getChildType(node.getChildIndex() + 1);
 
     if (nextNode == DelphiLexer.TRY) {
-      addViolation(data, node);
+      addViolation(ctx, node);
     }
-    return data;
   }
 }

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/TooLongMethodRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/TooLongMethodRule.java
@@ -26,13 +26,15 @@ import org.antlr.runtime.tree.Tree;
 import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 /**
  * Class for counting method lines. If too long, creates a violation.
  */
 public class TooLongMethodRule extends DelphiRule {
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
     if (node.getType() == DelphiLexer.PROCEDURE || node.getType() == DelphiLexer.FUNCTION) {
       Tree beginNode = null;
       // looking for begin statement
@@ -51,7 +53,7 @@ public class TooLongMethodRule extends DelphiRule {
 
       if (beginNode == null) {
         // no begin node, return
-        return data;
+        return;
       }
 
       int firstLine = node.getLine();
@@ -72,12 +74,10 @@ public class TooLongMethodRule extends DelphiRule {
 
         String msg = methodName.toString() + " is too long (" + lines + " lines). Maximum line count is "
           + limit;
-        addViolation(data, node, msg);
+        addViolation(ctx, node, msg);
         lastLineParsed = lastLine;
       }
     }
-
-    return data;
   }
 
   protected int getLastLine(Tree node) {

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/UnitNameRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/UnitNameRule.java
@@ -22,10 +22,12 @@ import org.antlr.runtime.tree.Tree;
 import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 public class UnitNameRule extends DelphiRule {
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
 
     if (node.getType() == DelphiLexer.UNIT) {
       for (int i = 0; i < node.getChildCount(); i++) {
@@ -37,12 +39,10 @@ public class UnitNameRule extends DelphiRule {
 
         char firstChar = child.getText().charAt(0);
         if (firstChar != Character.toUpperCase(firstChar)) {
-          addViolation(data, node);
+          addViolation(ctx, node);
           break;
         }
       }
     }
-
-    return data;
   }
 }

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/UnusedArgumentsRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/UnusedArgumentsRule.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import net.sourceforge.pmd.PropertyDescriptor;
+import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.properties.StringProperty;
 import org.antlr.runtime.tree.Tree;
 import org.sonar.plugins.delphi.antlr.DelphiLexer;
@@ -47,7 +48,7 @@ public class UnusedArgumentsRule extends DelphiRule {
   private final List<String> excludedArgs = new ArrayList<String>();
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
     if (node.getType() == DelphiLexer.PROCEDURE || node.getType() == DelphiLexer.FUNCTION) {
       Tree nameNode = node.getFirstChildWithType(DelphiLexer.TkFunctionName);
       if (nameNode != null) {
@@ -59,7 +60,7 @@ public class UnusedArgumentsRule extends DelphiRule {
 
       Tree argsNode = node.getFirstChildWithType(DelphiLexer.TkFunctionArgs);
       if (argsNode == null) {
-        return data;
+        return;
       }
 
       int lookIndex = 0;
@@ -74,21 +75,19 @@ public class UnusedArgumentsRule extends DelphiRule {
 
       if (beginNode == null || beginNode.getType() != DelphiLexer.BEGIN) {
         // no begin..end for function
-        return data;
+        return;
       }
 
       Map<String, Integer> args = processFunctionArgs(argsNode);
       if (args.isEmpty()) {
         // no arguments
-        return data;
+        return;
       }
 
       processFunctionBegin(beginNode, args);
-      checkForUnusedArguments(args, data, node);
+      checkForUnusedArguments(args, ctx, node);
 
     }
-
-    return data;
   }
 
   /**

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/UnusedArgumentsRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/UnusedArgumentsRule.java
@@ -97,10 +97,10 @@ public class UnusedArgumentsRule extends DelphiRule {
    * @param node
    * @param data
    */
-  private void checkForUnusedArguments(Map<String, Integer> args, Object data, DelphiPMDNode node) {
+  private void checkForUnusedArguments(Map<String, Integer> args, RuleContext ctx, DelphiPMDNode node) {
     for (Map.Entry<String, Integer> entry : args.entrySet()) {
       if (entry.getValue() == 0 && !ignoredArg(entry.getKey())) {
-        addViolation(data, node, "Unused argument: '" + entry.getKey() + "' at " + methodName);
+        addViolation(ctx, node, "Unused argument: '" + entry.getKey() + "' at " + methodName);
       }
     }
   }

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/UppercaseReservedWordsRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/UppercaseReservedWordsRule.java
@@ -25,6 +25,8 @@ package org.sonar.plugins.delphi.pmd.rules;
 import org.apache.commons.lang.StringUtils;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 /**
  * Rule checking if we are using some keyword with all uppercase characters.
  */
@@ -51,68 +53,67 @@ public class UppercaseReservedWordsRule extends DelphiRule {
   private static final String[] KEYWORDS_V = {"VAR"};
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
     if (StringUtils.isEmpty(node.getText())) {
-      return data;
+      return;
     }
     char firstChar = node.getText().charAt(0);
     switch (firstChar) {
       case 'A':
-        checkKeyword(node.getText(), KEYWORDS_A, node, data);
+        checkKeyword(node.getText(), KEYWORDS_A, node, ctx);
         break;
       case 'B':
-        checkKeyword(node.getText(), KEYWORDS_B, node, data);
+        checkKeyword(node.getText(), KEYWORDS_B, node, ctx);
         break;
       case 'C':
-        checkKeyword(node.getText(), KEYWORDS_C, node, data);
+        checkKeyword(node.getText(), KEYWORDS_C, node, ctx);
         break;
       case 'D':
-        checkKeyword(node.getText(), KEYWORDS_D, node, data);
+        checkKeyword(node.getText(), KEYWORDS_D, node, ctx);
         break;
       case 'E':
-        checkKeyword(node.getText(), KEYWORDS_E, node, data);
+        checkKeyword(node.getText(), KEYWORDS_E, node, ctx);
         break;
       case 'F':
-        checkKeyword(node.getText(), KEYWORDS_F, node, data);
+        checkKeyword(node.getText(), KEYWORDS_F, node, ctx);
         break;
       case 'G':
-        checkKeyword(node.getText(), KEYWORDS_G, node, data);
+        checkKeyword(node.getText(), KEYWORDS_G, node, ctx);
         break;
       case 'I':
-        checkKeyword(node.getText(), KEYWORDS_I, node, data);
+        checkKeyword(node.getText(), KEYWORDS_I, node, ctx);
         break;
       case 'L':
-        checkKeyword(node.getText(), KEYWORDS_L, node, data);
+        checkKeyword(node.getText(), KEYWORDS_L, node, ctx);
         break;
       case 'N':
-        checkKeyword(node.getText(), KEYWORDS_N, node, data);
+        checkKeyword(node.getText(), KEYWORDS_N, node, ctx);
         break;
       case 'O':
-        checkKeyword(node.getText(), KEYWORDS_O, node, data);
+        checkKeyword(node.getText(), KEYWORDS_O, node, ctx);
         break;
       case 'P':
-        checkKeyword(node.getText(), KEYWORDS_P, node, data);
+        checkKeyword(node.getText(), KEYWORDS_P, node, ctx);
         break;
       case 'R':
-        checkKeyword(node.getText(), KEYWORDS_R, node, data);
+        checkKeyword(node.getText(), KEYWORDS_R, node, ctx);
         break;
       case 'S':
-        checkKeyword(node.getText(), KEYWORDS_S, node, data);
+        checkKeyword(node.getText(), KEYWORDS_S, node, ctx);
         break;
       case 'T':
-        checkKeyword(node.getText(), KEYWORDS_T, node, data);
+        checkKeyword(node.getText(), KEYWORDS_T, node, ctx);
         break;
       case 'U':
-        checkKeyword(node.getText(), KEYWORDS_U, node, data);
+        checkKeyword(node.getText(), KEYWORDS_U, node, ctx);
         break;
       case 'W':
-        checkKeyword(node.getText(), KEYWORDS_W, node, data);
+        checkKeyword(node.getText(), KEYWORDS_W, node, ctx);
         break;
       case 'V':
-        checkKeyword(node.getText(), KEYWORDS_V, node, data);
+        checkKeyword(node.getText(), KEYWORDS_V, node, ctx);
         break;
     }
-    return data;
   }
 
   protected void checkKeyword(String keyword, String[] keywords, DelphiPMDNode node, Object data) {

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/UppercaseReservedWordsRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/UppercaseReservedWordsRule.java
@@ -116,11 +116,11 @@ public class UppercaseReservedWordsRule extends DelphiRule {
     }
   }
 
-  protected void checkKeyword(String keyword, String[] keywords, DelphiPMDNode node, Object data) {
+  protected void checkKeyword(String keyword, String[] keywords, DelphiPMDNode node, RuleContext ctx) {
     for (String key : keywords) {
       if (keyword.equals(key)) {
         String msg = "Avoid using uppercase keywords: " + keyword;
-        addViolation(data, node, msg);
+        addViolation(ctx, node, msg);
       }
     }
   }

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/VariableCounter.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/VariableCounter.java
@@ -26,6 +26,8 @@ import org.antlr.runtime.tree.Tree;
 import org.sonar.plugins.delphi.antlr.DelphiLexer;
 import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 
+import net.sourceforge.pmd.RuleContext;
+
 /**
  * Rule that is checking how many arguments a function has - if too many, it
  * triggers a violation
@@ -33,7 +35,7 @@ import org.sonar.plugins.delphi.antlr.ast.DelphiPMDNode;
 public class VariableCounter extends DelphiRule {
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
     // if function arguments node
     if (node.getText().equals(getStringProperty(START))) {
       int count = 0;
@@ -50,10 +52,9 @@ public class VariableCounter extends DelphiRule {
       if (count > limit) {
         String msg = "Too many " + getStringProperty(LOOK_FOR) + ": " + count + " (max "
           + limit + ")";
-        addViolation(data, node, msg);
+        addViolation(ctx, node, msg);
       }
     }
-    return data;
   }
 
 }

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/XPathRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/XPathRule.java
@@ -61,10 +61,10 @@ public class XPathRule extends DelphiRule {
    */
 
   @Override
-  public Object visit(DelphiPMDNode node, Object data) {
+  public void visit(DelphiPMDNode node, RuleContext ctx) {
     String xPathString = getStringProperty(XPATH);
     if (StringUtils.isEmpty(xPathString)) {
-      return data;
+      return;
     }
     Document doc = getCachedDocument(node.getASTTree());
     try {
@@ -87,17 +87,15 @@ public class XPathRule extends DelphiRule {
 
         int column = Integer.valueOf(resultNode.getAttributes().getNamedItem("column").getTextContent());
         String msg = this.getMessage().replaceAll("\\{\\}", resultNode.getTextContent());
-        DelphiRuleViolation violation = new DelphiRuleViolation(this, (RuleContext) data, className,
+        DelphiRuleViolation violation = new DelphiRuleViolation(this, (RuleContext) ctx, className,
           methodName, packageName, line, column,
           msg);
-        addViolation(data, violation);
+        addViolation(ctx, violation);
       }
     } catch (Exception e) {
       DelphiUtils.LOG.debug("XPath error: '" + e.getMessage() + "' at rule " + getName());
       e.printStackTrace();
     }
-
-    return data;
   }
 
   /**


### PR DESCRIPTION
> **Update**. I found [AbstractJavaRule javadoc](http://pmd.sourceforge.net/pmd-4.2.5/apidocs/net/sourceforge/pmd/AbstractJavaRule.html) and discovered that these methods simply mimic the signature of all those other `visit` methods. So I'm not so sure about this PR anymore. On the other hand - do we need to keep this signature? Can this change be the source of problems sometime later?

I started to learn what information I have available in the rule's `visit` method. And the first intriguing thing was that mystical `Object data` that's received, used only in `addViolation` call and then returned back. So I found [the only place where `visit` gets called](https://github.com/fabriciocolombo/sonar-delphi/blob/master/src/main/java/org/sonar/plugins/delphi/pmd/rules/DelphiRule.java#L86) to see what's _really_ passed in. And found out that it is an instance of `RuleContext`. Also I noticed that return value is not used, which means that `return data;` line in the rule is meaningless. So I updated the signature to match the way it really is used.

Then I noticed that the same pattern of receiving plain `Object` and then casting it to the real type of `RuleContext` is used a little below in 3 `addViolation` methods. Again, I saw no bonus to do that (and nothing else can be passed in anyway, cause then we'll immediately get `java.lang.ClassCastException`, right?) and updated the signature to match the reality.

And all the tests still pass, so why not?
