### PR TITLE
Fixed CountRule and ClassPerFileRule

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/ClassPerFileRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/ClassPerFileRule.java
@@ -35,6 +35,7 @@ public class ClassPerFileRule extends CountRule {
   @Override
   protected void init() {
     super.init();
+    reset = false;
     setTypeToSearch(DelphiLexer.TkClass);
   }
 

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/CountRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/CountRule.java
@@ -37,14 +37,13 @@ public class CountRule extends DelphiRule {
   protected int limit;
   protected int count;
   /**
-   * Number to increase the count. 
+   * Number to increase the count.
    */
   protected int strength = 1;
   /**
-   * Should we reset counter after exceeding  the limit.
+   * Should we reset the counter after exceeding the limit.
    */
   protected boolean reset = true;
-  protected Object dataRef = null;
 
   public String getStringToSearch() {
     return stringToSearch;
@@ -60,10 +59,11 @@ public class CountRule extends DelphiRule {
 
   @Override
   public void visit(DelphiPMDNode node, RuleContext ctx) {
-    dataRef = ctx;
-    if (shouldCount(node)) {
-      increaseCounter(strength);
+    if (!shouldCount(node)) {
+      return;
     }
+
+    increaseCounter(strength);
 
     if (exceedsLimit()) {
       addViolation(ctx, node);
@@ -74,8 +74,15 @@ public class CountRule extends DelphiRule {
   }
 
   protected boolean shouldCount(DelphiPMDNode node) {
-    return node.getText().equals(stringToSearch) ||
-      node.getType() == typeToSearch;
+    return matchesText(node) || matchesType(node);
+  }
+
+  protected boolean matchesText(DelphiPMDNode node) {
+    return node.getText().equals(stringToSearch);
+  }
+
+  protected boolean matchesType(DelphiPMDNode node) {
+    return node.getType() == typeToSearch;
   }
 
   protected void increaseCounter(int howMuch) {

--- a/src/test/java/org/sonar/plugins/delphi/pmd/ClassPerFileRuleTest.java
+++ b/src/test/java/org/sonar/plugins/delphi/pmd/ClassPerFileRuleTest.java
@@ -55,6 +55,25 @@ public class ClassPerFileRuleTest extends BasePmdRuleTest {
   }
 
   @Test
+  public void allClassesAfterFirstOneShouldAddIssue() {
+    DelphiUnitBuilderTest builder = new DelphiUnitBuilderTest();
+    builder.appendDecl("type");
+    builder.appendDecl("  TMyClass = class");
+    builder.appendDecl("  end;");
+    builder.appendDecl("  TMyClass2 = class");
+    builder.appendDecl("  end;");
+    builder.appendDecl("  TMyClass3 = class");
+    builder.appendDecl("  end;");
+
+    analyse(builder);
+
+    assertThat(issues, hasSize(2));
+    assertThat(issues, hasItem(hasRuleKey("OneClassPerFileRule")));
+    assertThat(issues, hasItem(hasRuleLine(builder.getOffsetDecl() + 4)));
+    assertThat(issues, hasItem(hasRuleLine(builder.getOffsetDecl() + 6)));
+  }
+
+  @Test
   public void falsePositiveMetaClass() {
     DelphiUnitBuilderTest builder = new DelphiUnitBuilderTest();
     builder.appendDecl("type");


### PR DESCRIPTION
`ClassPerFileRule` should mark all classes after the first one as violations, but it ignored every other class. It was because the counter was reset after adding a violation. 
It worked like this:

```
TMyClass1 <- the counter increases to 1
TMyClass2 <- a violation is added, the counter resets to 0
TMyClass3 <- the counter increases to 1
TMyClass4 <- a violation is added, the counter resets to 0
etc.
```

After setting `reset = false;` number of violations suddenly increased to huge numbers. For a simple test with 5 classes, 21 violation was registered instead of 4. It was because of a bug in `CountRule`. After the limit was exceeced, a violation was added to _every_ node, not just to those that match the search criteria. So I turned `shouldCheck` into a guard clause that returns immediately if the node does not match.

Also I removed `Object dataRef` instance variable from `CountRule`, because it seems unused.
