### PR TITLE
Fixed DelphiPMDNode.internalfindAllChildren

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/antlr/ast/DelphiPMDNode.java
+++ b/src/main/java/org/sonar/plugins/delphi/antlr/ast/DelphiPMDNode.java
@@ -137,18 +137,18 @@ public class DelphiPMDNode extends DelphiNode implements JavaNode, CompilationUn
     return jjtAccept((DelphiParserVisitor) visitor, data);
   }
 
-  public List<Tree> findAllChilds(int type) {
-    return internalfindAllChilds(this, type);
+  public List<Tree> findAllChildren(int type) {
+    return internalfindAllChildren(this, type);
   }
 
-  public List<Tree> internalfindAllChilds(Tree node, int type) {
+  public List<Tree> internalfindAllChildren(Tree node, int type) {
     List<Tree> result = new ArrayList<Tree>();
     for (int i = 0; i < node.getChildCount(); i++) {
       Tree child = node.getChild(i);
-      if (child.getType() == DelphiLexer.TkFunctionName) {
+      if (child.getType() == type) {
         result.add(child);
       } else {
-        result.addAll(internalfindAllChilds(child, type));
+        result.addAll(internalfindAllChildren(child, type));
       }
     }
     return result;

--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/MethodNameRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/MethodNameRule.java
@@ -32,7 +32,7 @@ public class MethodNameRule extends DelphiRule {
 
     if (node.getType() == DelphiLexer.TkNewType) {
       if (isInterface(node) || !isPublished()) {
-        List<Tree> methodNodes = node.findAllChilds(DelphiLexer.TkFunctionName);
+        List<Tree> methodNodes = node.findAllChildren(DelphiLexer.TkFunctionName);
 
         for (Tree method : methodNodes) {
           String name = method.getChild(0).getText();


### PR DESCRIPTION
As the only place from where this method (and its parent method) is invoked is `MethodNameRule`, that is interested in type `DelphiLexer.TkFunctionName`, this hardcoded value was left in the generic version.

Also updated the name itself to better match English grammar.
