### PR TITLE
Resetting inImplementationSection for each file

### DIFF
--- a/src/main/java/org/sonar/plugins/delphi/pmd/rules/DelphiRule.java
+++ b/src/main/java/org/sonar/plugins/delphi/pmd/rules/DelphiRule.java
@@ -69,6 +69,7 @@ public class DelphiRule extends AbstractJavaRule {
   protected void visitAll(@SuppressWarnings("rawtypes") List acus, RuleContext ctx) {
     lastLineParsed = -1;
     currentVisibility = DelphiLexer.PUBLISHED;
+    inImplementationSection = false;
     init();
     for (Iterator<?> i = acus.iterator(); i.hasNext();) {
       DelphiPMDNode node = (DelphiPMDNode) i.next();


### PR DESCRIPTION
A private boolean variable introduced in ba078a1c was not reset back to `false` after a unit was processed, so, after the first file containing an implementation section, _everything_ was considered to be inside of implementation. And that caused `NoSemicolonRule` to crash on a following `dpk` file.

I don't know how to test this with a unit test though, as it requires 2 files to be processed.
